### PR TITLE
Converts Models to using Parent ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dist
 /src/config.codekit
 /src/styles/.sass-cache
 /src/.codekit-cache
+/src/firebase

--- a/src/scripts/components/Act/Card.js
+++ b/src/scripts/components/Act/Card.js
@@ -39,7 +39,7 @@ var ActCard = React.createClass({
                         <ButtonLink bsStyle="primary" bsSize="small" to="manage-quests" params={{campaignId: campaign.id, actId: act.id}}><Glyphicon glyph="cog" /> Quests</ButtonLink>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={act} model={this.props.model} related={{key: 'campaign_id', on: campaign}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={act} model={this.props.model} parent={campaign} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={act} onUpdate={this.props.onUpdate}>
                             <p className="text-danger">
                             This will also <strong>remove</strong> all associated:

--- a/src/scripts/components/Act/ManagePage.js
+++ b/src/scripts/components/Act/ManagePage.js
@@ -94,7 +94,7 @@ var ActManagePage = React.createClass({
                 <div id="act-manage-page" className="page-content">
                     <Breadcrumb crumbs={crumbs} />
                     <PageHeader pageName={campaign.attrs.name} pageType="Acts">
-                        <FormModal model={ActModel} related={{key: 'campaign_id', on: campaign}} inputs={self.getInputs.bind({})} onUpdate={self.getActs} />
+                        <FormModal model={ActModel} parent={campaign} inputs={self.getInputs.bind({})} onUpdate={self.getActs} />
                     </PageHeader>
                     <div className="row">
                         {self.state.acts.map(function(act) {

--- a/src/scripts/components/Area/Card.js
+++ b/src/scripts/components/Area/Card.js
@@ -39,7 +39,7 @@ var AreaCard = React.createClass({
                         <Button bsStyle="warning" bsSize="small"><Glyphicon glyph="plus" /> Encounter</Button>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={area} model={this.props.model} related={{key: 'location_id', on: location}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={area} model={this.props.model} parent={location} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={area} onUpdate={this.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Area/ManagePage.js
+++ b/src/scripts/components/Area/ManagePage.js
@@ -220,9 +220,9 @@ var AreaManagePage = React.createClass({
                 <div id="area-manage-page" className="page-content">
                     <Breadcrumb crumbs={crumbs} />
                     <PageHeader pageName={location.attrs.name} pageType="Areas, Shops, & Bounties">
-                        <FormModal model={AreaModel} related={{key: 'location_id', on: location}} inputs={self.getAreaInputs.bind(self, {})} onUpdate={self.getAreas} />
-                        <FormModal model={ShopModel} related={{key: 'location_id', on: location}} inputs={self.getShopInputs.bind(self, {})} onUpdate={self.getShops} />
-                        <FormModal model={BountyModel} related={{key: 'location_id', on: location}} inputs={self.getBountyInputs.bind(self, {})} onUpdate={self.getBounties} />
+                        <FormModal model={AreaModel} parent={location} inputs={self.getAreaInputs.bind(self, {})} onUpdate={self.getAreas} />
+                        <FormModal model={ShopModel} parent={location} inputs={self.getShopInputs.bind(self, {})} onUpdate={self.getShops} />
+                        <FormModal model={BountyModel} parent={location} inputs={self.getBountyInputs.bind(self, {})} onUpdate={self.getBounties} />
                     </PageHeader>
                    <div className="row">
                         <div className="col-md-12">

--- a/src/scripts/components/Battle/Card.js
+++ b/src/scripts/components/Battle/Card.js
@@ -54,7 +54,7 @@ var BattleCard = React.createClass({
                         <LinkModal target={battle} onUpdate={self.props.onUpdate} />
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={battle} model={this.props.model} related={{key: 'user_id', on: Auth.User}} inputs={this.props.inputs} onUpdate={self.props.onUpdate} />
+                        <FormModal target={battle} model={this.props.model} parent={Auth.User} inputs={this.props.inputs} onUpdate={self.props.onUpdate} />
                         <RemoveModal target={battle} onUpdate={self.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Bounty/Card.js
+++ b/src/scripts/components/Bounty/Card.js
@@ -40,7 +40,7 @@ var BountyCard = React.createClass({
                         <Button bsSize="small" bsStyle="warning"><Glyphicon glyph="link" /> Encounter</Button>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={bounty} model={this.props.model} related={{key: 'location_id', on: location}} inputs={this.props.inputs} onUpdate={self.props.onUpdate} />
+                        <FormModal target={bounty} model={this.props.model} parent={location} inputs={this.props.inputs} onUpdate={self.props.onUpdate} />
                         <RemoveModal target={bounty} onUpdate={self.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Campaign/Card.js
+++ b/src/scripts/components/Campaign/Card.js
@@ -41,7 +41,7 @@ var CampaignCard = React.createClass({
                         <ButtonLink bsStyle="primary" bsSize="small" to="manage-locations" params={{campaignId: campaign.id}}><Glyphicon glyph="cog" /> Locations</ButtonLink>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={campaign} model={this.props.model} related={{key: 'user_id', on: Auth.User}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={campaign} model={this.props.model} parent={Auth.User} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={campaign} onUpdate={this.props.onUpdate}>
                             <p className="text-danger">
                                 This will also <strong>remove</strong> all associated:

--- a/src/scripts/components/Campaign/ManagePage.js
+++ b/src/scripts/components/Campaign/ManagePage.js
@@ -72,7 +72,7 @@ var CampaignManagePage = React.createClass({
             <div id="campaign-manage-page" className="page-content">
                 <Breadcrumb crumbs={crumbs} />
                 <PageHeader pageName="Campaigns">
-                    <FormModal model={Model} related={{key: 'user_id', on: Auth.User}} inputs={self.getCampaignInputs.bind(self, {})} onUpdate={self.getCampaigns} />
+                    <FormModal model={Model} parent={Auth.User} inputs={self.getCampaignInputs.bind(self, {})} onUpdate={self.getCampaigns} />
                 </PageHeader>
                 <div className="row">
                     {self.state.campaigns.map(function(campaign) {

--- a/src/scripts/components/Character/Card.js
+++ b/src/scripts/components/Character/Card.js
@@ -40,7 +40,7 @@ var CharacterCard = React.createClass({
                         <span />
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={character} model={this.props.model} related={{key: 'user_id', on: Auth.User}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={character} model={this.props.model} parent={Auth.User} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={character} onUpdate={this.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Character/ManagePage.js
+++ b/src/scripts/components/Character/ManagePage.js
@@ -74,7 +74,7 @@ var CharacterManagePage = React.createClass({
         return (
             <div id="characters-manage-page" className="page-content">
                 <PageHeader pageName="Characters">
-                    <FormModal model={Model} related={{key: 'user_id', on: Auth.User}} inputs={self.getCharacterInputs.bind(self, {})} onUpdate={self.getCharacters} />
+                    <FormModal model={Model} parent={Auth.User} inputs={self.getCharacterInputs.bind(self, {})} onUpdate={self.getCharacters} />
                 </PageHeader>
                 <div className="row">
                     {self.state.characters.map(function(character) {

--- a/src/scripts/components/Foe/Card.js
+++ b/src/scripts/components/Foe/Card.js
@@ -42,7 +42,7 @@ var FoeCard = React.createClass({
                         <span />
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={foe} model={this.props.model} related={{key: 'user_id', on: Auth.User}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={foe} model={this.props.model} parent={Auth.User} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={foe} onUpdate={this.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Foe/ManagePage.js
+++ b/src/scripts/components/Foe/ManagePage.js
@@ -113,8 +113,8 @@ var FoeManagePage = React.createClass({
         return (
             <div id="foe-manage-page" className="page-content">
                 <PageHeader pageName="Foes">
-                    <FormModal model={FoeModel} related={{key: 'user_id', on: Auth.User}} inputs={self.getFoeInputs.bind(self, {})} onUpdate={self.getFoes} />
-                    <FormModal model={BattleModel} related={{key: 'user_id', on: Auth.User}} inputs={self.getBattleInputs.bind(self, {})} onUpdate={self.getBattles} />
+                    <FormModal model={FoeModel} parent={Auth.User} inputs={self.getFoeInputs.bind(self, {})} onUpdate={self.getFoes} />
+                    <FormModal model={BattleModel} parent={Auth.User} inputs={self.getBattleInputs.bind(self, {})} onUpdate={self.getBattles} />
                 </PageHeader>
                 <div className="row">
                     <div className="col-md-12">

--- a/src/scripts/components/Location/Card.js
+++ b/src/scripts/components/Location/Card.js
@@ -40,7 +40,7 @@ var LocationCard = React.createClass({
                         <ButtonLink bsStyle="primary" bsSize="small" to="manage-areas" params={{campaignId: campaign.id, locationId: location.id}}><Glyphicon glyph="cog" /> Areas, Shops, &amp; Bounties</ButtonLink>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={location} model={this.props.model} related={{key: 'campaign_id', on: campaign}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={location} model={this.props.model} parent={campaign} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={location} onUpdate={this.props.onUpdate}>
                             <p className="text-danger">
                                 This will also <strong>remove</strong> all associated:

--- a/src/scripts/components/Location/ManagePage.js
+++ b/src/scripts/components/Location/ManagePage.js
@@ -100,7 +100,7 @@ var LocationManagePage = React.createClass({
                 <div id="location-manage-page" className="page-content">
                     <Breadcrumb crumbs={crumbs} />
                     <PageHeader pageName={campaign.attrs.name} pageType="Locations">
-                        <FormModal model={Model} related={{key: 'campaign_id', on: campaign}} inputs={self.getLocationInputs.bind(self, {})} onUpdate={self.getLocations} />
+                        <FormModal model={Model} parent={campaign} inputs={self.getLocationInputs.bind(self, {})} onUpdate={self.getLocations} />
                     </PageHeader>
                     <div className="row">
                         {self.state.locations.map(function(location) {

--- a/src/scripts/components/Model/FormModal.js
+++ b/src/scripts/components/Model/FormModal.js
@@ -44,9 +44,9 @@ var ModelFormModal = React.createClass({
             data[name] = input.value;
         });
 
-        var related = this.props.related;
-        if (_.isObject(related)) {
-            data[related.key] = related.on.id;
+        var parent = this.props.parent;
+        if (_.isObject(parent)) {
+            data['parent_id'] = parent.id;
         }
 
         var target = this.props.target;

--- a/src/scripts/components/Quest/Card.js
+++ b/src/scripts/components/Quest/Card.js
@@ -40,7 +40,7 @@ var QuestCard = React.createClass({
                         <ButtonLink bsStyle="primary" bsSize="small" to="manage-tasks" params={{campaignId: campaign.id, actId: act.id, questId: quest.id}}><Glyphicon glyph="cog" /> Tasks</ButtonLink>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={quest} model={this.props.model} related={{key:'act_id', on: act}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={quest} model={this.props.model} parent={act} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={quest} onUpdate={this.props.onUpdate}>
                             <p className="text-danger">
                                 This will also <strong>remove</strong> all associated:

--- a/src/scripts/components/Quest/ManagePage.js
+++ b/src/scripts/components/Quest/ManagePage.js
@@ -89,7 +89,7 @@ var QuestManagePage = React.createClass({
                 <div id="quest-manage-page" className="page-content">
                     <Breadcrumb crumbs={crumbs} />
                     <PageHeader pageName={act.attrs.name} pageType="Quests">
-                        <FormModal model={QuestModel} related={{key: 'act_id', on: act}} inputs={self.getQuestInputs.bind(self, {})} onUpdate={self.getQuests} />
+                        <FormModal model={QuestModel} parent={act} inputs={self.getQuestInputs.bind(self, {})} onUpdate={self.getQuests} />
                     </PageHeader>
                     <div className="row">
                         {self.state.quests.map(function(quest){

--- a/src/scripts/components/Shop/Card.js
+++ b/src/scripts/components/Shop/Card.js
@@ -71,7 +71,7 @@ var ShopCard = React.createClass({
                         <Button bsStyle="warning" bsSize="small"><Glyphicon glyph="link" /> Encounter</Button>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={shop} model={this.props.model} related={{key: 'location_id', on: location}} inputs={this.props.inputs} onUpdate={self.props.onUpdate} />
+                        <FormModal target={shop} model={this.props.model} parent={location} inputs={this.props.inputs} onUpdate={self.props.onUpdate} />
                         <RemoveModal target={shop} onUpdate={self.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Task/Card.js
+++ b/src/scripts/components/Task/Card.js
@@ -42,7 +42,7 @@ var TaskCard = React.createClass({
                         <Button bsStyle="warning" bsSize="small"><Glyphicon glyph="plus" /> Encounter</Button>
                     </ButtonToolbar>
                     <ButtonToolbar className="pull-right">
-                        <FormModal target={task} model={this.props.model} related={{key: 'quest_id', on: task}} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
+                        <FormModal target={task} model={this.props.model} parent={task} inputs={this.props.inputs} onUpdate={this.props.onUpdate} />
                         <RemoveModal target={task} onUpdate={this.props.onUpdate} />
                     </ButtonToolbar>
                 </div>

--- a/src/scripts/components/Task/ManagePage.js
+++ b/src/scripts/components/Task/ManagePage.js
@@ -119,7 +119,7 @@ var TaskManagePage = React.createClass({
                 <div id="task-manage-page" className="page-content">
                     <Breadcrumb crumbs={crumbs} />
                     <PageHeader pageName={quest.attrs.name} pageType="Tasks">
-                        <FormModal model={TaskModel} related={{key: 'quest_id', on: quest}} inputs={self.getTaskInputs.bind(self, {})} onUpdate={self.getTasks} />
+                        <FormModal model={TaskModel} parent={quest} inputs={self.getTaskInputs.bind(self, {})} onUpdate={self.getTasks} />
                     </PageHeader>
                     <div className="row">
                         {self.state.tasks.map(function(task){

--- a/src/scripts/models/ActModel.js
+++ b/src/scripts/models/ActModel.js
@@ -11,7 +11,7 @@ function ActModel() {
     this.name = 'act';
 
     this.attrs = {
-        campaign_id: null,
+        parent_id: null,
         order: null,
 
         name: null,
@@ -21,7 +21,7 @@ function ActModel() {
     };
 
     this.getQuests = function() {
-        return this.getRelated(QuestModel, 'act_id', 'order');
+        return this.getRelated(QuestModel, 'order');
     }
 }
 

--- a/src/scripts/models/AreaModel.js
+++ b/src/scripts/models/AreaModel.js
@@ -11,7 +11,7 @@ function AreaModel() {
     this.name = 'area';
 
     this.attrs = {
-        location_id: null,
+        parent_id: null,
 
         name: null,
         type: null,
@@ -20,7 +20,7 @@ function AreaModel() {
     };
 
     this.getEncounters = function() {
-        return this.getRelated(EncounterModel, 'parent_id', 'order');
+        return this.getRelated(EncounterModel, 'order');
     }
 }
 

--- a/src/scripts/models/BaseModel.js
+++ b/src/scripts/models/BaseModel.js
@@ -130,13 +130,13 @@ BaseModel.prototype.get = function(id) {
     return deferred.promise;
 };
 
-BaseModel.prototype.getRelated = function(RelatedModel, link_key, sort_key) {
+BaseModel.prototype.getRelated = function(RelatedModel, sort_key) {
     var deferred = Q.defer();
 
     var self = this;
 
     new RelatedModel().fb_ref
-        .orderByChild(link_key)
+        .orderByChild('parent_id')
         .equalTo(self.id)
         .once('value', function(snapshot) {
             if (snapshot !== null) {

--- a/src/scripts/models/BattleModel.js
+++ b/src/scripts/models/BattleModel.js
@@ -15,7 +15,7 @@ function BattleModel() {
     this.name = 'group';
 
     this.attrs = {
-        user_id: null,
+        parent_id: null,
 
         name: null,
         type: null,

--- a/src/scripts/models/BountyModel.js
+++ b/src/scripts/models/BountyModel.js
@@ -11,7 +11,7 @@ function BountyModel() {
     this.name = 'bounty';
 
     this.attrs = {
-        location_id: null,
+        parent_id: null,
 
         name: null,
         type: null,
@@ -25,7 +25,7 @@ function BountyModel() {
     };
 
     this.getTasks = function() {
-        return this.getRelated(TaskModel, 'bounty_id', 'order');
+        return this.getRelated(TaskModel, 'order');
     }
 }
 

--- a/src/scripts/models/CampaignModel.js
+++ b/src/scripts/models/CampaignModel.js
@@ -12,7 +12,7 @@ function CampaignModel() {
     this.name = 'campaign';
 
     this.attrs = {
-        user_id: null,
+        parent_id: null,
         order: null,
 
         name: null,
@@ -21,11 +21,11 @@ function CampaignModel() {
     };
 
     this.getActs = function() {
-        return this.getRelated(ActModel, 'campaign_id', 'order');
+        return this.getRelated(ActModel, 'order');
     };
 
     this.getLocations = function() {
-        return this.getRelated(LocationModel, 'campaign_id', 'order');
+        return this.getRelated(LocationModel, 'order');
     };
 }
 

--- a/src/scripts/models/CharacterModel.js
+++ b/src/scripts/models/CharacterModel.js
@@ -10,7 +10,7 @@ function CharacterModel() {
     this.name = 'character';
 
     this.attrs = {
-        user_id: null,
+        parent_id: null,
 
         name: null,
         type: null,

--- a/src/scripts/models/FoeModel.js
+++ b/src/scripts/models/FoeModel.js
@@ -10,7 +10,7 @@ function FoeModel() {
     this.name = 'foe';
 
     this.attrs = {
-        user_id: null,
+        parent_id: null,
 
         name: null,
         type: null,

--- a/src/scripts/models/LocationModel.js
+++ b/src/scripts/models/LocationModel.js
@@ -13,7 +13,7 @@ function LocationModel() {
     this.name = 'location';
 
     this.attrs = {
-        campaign_id: null,
+        parent_id: null,
 
         name: null,
         type: null,
@@ -23,15 +23,15 @@ function LocationModel() {
     };
 
     this.getAreas = function() {
-        return this.getRelated(AreaModel, 'location_id', 'name');
+        return this.getRelated(AreaModel, 'name');
     };
 
     this.getShops = function() {
-        return this.getRelated(ShopModel, 'location_id', 'name');
+        return this.getRelated(ShopModel, 'name');
     };
 
     this.getBounties = function() {
-        return this.getRelated(BountyModel, 'location_id', 'rewardXp');
+        return this.getRelated(BountyModel, 'rewardXp');
     };
 }
 

--- a/src/scripts/models/QuestModel.js
+++ b/src/scripts/models/QuestModel.js
@@ -11,7 +11,7 @@ function QuestModel() {
     this.name = 'quest';
 
     this.attrs = {
-        act_id: null,
+        parent_id: null,
         order: null,
 
         name: null,
@@ -26,7 +26,7 @@ function QuestModel() {
     };
 
     this.getTasks = function() {
-        return this.getRelated(TaskModel, 'quest_id', 'order');
+        return this.getRelated(TaskModel, 'order');
     }
 }
 

--- a/src/scripts/models/ShopModel.js
+++ b/src/scripts/models/ShopModel.js
@@ -14,7 +14,7 @@ function ShopModel() {
     this.name = 'shop';
 
     this.attrs = {
-        location_id: null,
+        parent_id: null,
 
         name: null,
         type: null,
@@ -56,7 +56,7 @@ function ShopModel() {
     };
 
     this.getEncounters = function() {
-        return this.getRelated(EncounterModel, 'parent_id', 'order');
+        return this.getRelated(EncounterModel, 'order');
     }
 }
 

--- a/src/scripts/models/TaskModel.js
+++ b/src/scripts/models/TaskModel.js
@@ -11,7 +11,7 @@ function TaskModel() {
     this.name = 'task';
 
     this.attrs = {
-        quest_id: null,
+        parent_id: null,
         order: null,
 
         name: null,
@@ -20,7 +20,7 @@ function TaskModel() {
     };
 
     this.getEncounters = function() {
-        return this.getRelated(EncounterModel, 'parent_id', 'order');
+        return this.getRelated(EncounterModel, 'order');
     }
 }
 

--- a/src/scripts/models/UserModel.js
+++ b/src/scripts/models/UserModel.js
@@ -19,19 +19,19 @@ function UserModel() {
     };
 
     this.getCampaigns = function() {
-        return this.getRelated(CampaignModel, 'user_id', 'order');
+        return this.getRelated(CampaignModel, 'order');
     };
 
     this.getCharacters = function() {
-        return this.getRelated(CharacterModel, 'user_id', 'name');
+        return this.getRelated(CharacterModel, 'name');
     };
 
     this.getFoes = function() {
-        return this.getRelated(FoeModel, 'user_id', 'name');
+        return this.getRelated(FoeModel, 'name');
     };
 
     this.getBattles = function() {
-        return this.getRelated(BattleModel, 'user_id', 'name');
+        return this.getRelated(BattleModel, 'name');
     };
 }
 


### PR DESCRIPTION
Instead of specifically citing the model_id, all related keys have been changed to the more generic parent_id.

This allows for simpler code and linking of models.