### PR TITLE
Properly sorts models by strings

### DIFF
--- a/src/scripts/models/BaseModel.js
+++ b/src/scripts/models/BaseModel.js
@@ -209,11 +209,13 @@ BaseModel.prototype.remove = function() {
 };
 
 BaseModel.prototype.sortModels = function(array, key) {
+    console.log(array, key);
+
     var compare = function(a, b) {
         var a_val = a.attrs[key];
         var b_val = b.attrs[key];
 
-        if (_.isNumber(parseInt(a_val)) && _.isNumber(parseInt(b_val))) {
+        if (!_.isNaN(+a_val) && !_.isNaN(+b_val)) {
             a_val = parseInt(a_val);
             b_val = parseInt(b_val);
         }


### PR DESCRIPTION
My tests to check for numeric strings vs regular strings was failing as parseInt was returning a valid number (of 0) for strings.

Decided to alter the test by adding nothing to the string which will result in NaN for non-number strings and testing against that.